### PR TITLE
fix: Remove spaces from IAM policy sids

### DIFF
--- a/.github/workflows/pre-commit-pr.yml
+++ b/.github/workflows/pre-commit-pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3    
+      - uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
         with:
           # renovate: datasource=github-tags depName=opentofu/opentofu versioning=semver
           tofu_version: 1.8.1
@@ -48,6 +48,7 @@ jobs:
           output-method: inject
           git-push: false
           fail-on-diff: true
+          args: "--lockfile=false"
 
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@19a52fbac37dacb22a09518e4ef6ee234f2d4987 # v4.0.0
@@ -62,7 +63,7 @@ jobs:
         run: tflint --init
         env:
           # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run TFLint
         run: tflint -f compact --recursive
@@ -77,7 +78,7 @@ jobs:
       - name: tfsec
         uses: aquasecurity/tfsec-action@b466648d6e39e7c75324f25d83891162a721f2d6 # v1.0.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }} 
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           soft_fail: true
 
   regula:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ go test -count 1 -v .
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.63.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.62.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "kms_access" {
   # checkov:skip=CKV_AWS_111: todo reduce perms on key
   # checkov:skip=CKV_AWS_109: todo be more specific with resources
   statement {
-    sid = "KMS Key Default"
+    sid = "KMSKeyDefault"
     principals {
       type = "AWS"
       identifiers = concat(
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "kms_access" {
     resources = ["*"]
   }
   statement {
-    sid = "Cloudtrail KMS permissions"
+    sid = "CloudtrailKMSpermissions"
     principals {
       type = "Service"
       identifiers = [


### PR DESCRIPTION
### Summary

This PR addresses an issue discovered with spaces in SIDs, which was identified after the terraform AWS provider update to version 5.82.0 introduced additional validation. The update caused errors due to invalid SIDs containing spaces, as SIDs must not contain spaces according to [AWS IAM policy documentation]. The additional validation added in 5.82.0 has since been reverted (it caused additional issues, see: https://github.com/hashicorp/terraform-provider-aws/issues/40639) and 5.82.1 was released without the validation. However it brought to light that spaces are not allowed in IAM Policy Document SIDs. Ref: (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html).

### Changes Made
- Removed spaces from SIDs to comply with AWS formatting rules for IAM policy documents.

### References
- [AWS IAM Policy Documentation: SIDs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_sid.html)